### PR TITLE
Replace alloc.destroy with std::allocator_traits<std::allocator<T>>::…

### DIFF
--- a/lemon/bits/array_map.h
+++ b/lemon/bits/array_map.h
@@ -219,7 +219,7 @@ namespace lemon {
           int jd = nf->id(it);;
           if (id != jd) {
             allocator.construct(&(new_values[jd]), values[jd]);
-            allocator.destroy(&(values[jd]));
+            std::allocator_traits<std::allocator<Value>>::destroy(allocator, &(values[jd]));
           }
         }
         if (capacity != 0) allocator.deallocate(values, capacity);
@@ -261,7 +261,7 @@ namespace lemon {
           }
           if (found) continue;
           allocator.construct(&(new_values[id]), values[id]);
-          allocator.destroy(&(values[id]));
+          std::allocator_traits<std::allocator<Value>>::destroy(allocator, &(values[id]));
         }
         if (capacity != 0) allocator.deallocate(values, capacity);
         values = new_values;
@@ -279,7 +279,7 @@ namespace lemon {
     // and it overrides the erase() member function of the observer base.
     virtual void erase(const Key& key) {
       int id = Parent::notifier()->id(key);
-      allocator.destroy(&(values[id]));
+      std::allocator_traits<std::allocator<Value>>::destroy(allocator, &(values[id]));
     }
 
     // \brief Erase more keys from the map.
@@ -289,7 +289,7 @@ namespace lemon {
     virtual void erase(const std::vector<Key>& keys) {
       for (int i = 0; i < int(keys.size()); ++i) {
         int id = Parent::notifier()->id(keys[i]);
-        allocator.destroy(&(values[id]));
+        std::allocator_traits<std::allocator<Value>>::destroy(allocator, &(values[id]));
       }
     }
 
@@ -317,7 +317,7 @@ namespace lemon {
         Item it;
         for (nf->first(it); it != INVALID; nf->next(it)) {
           int id = nf->id(it);
-          allocator.destroy(&(values[id]));
+          std::allocator_traits<std::allocator<Value>>::destroy(allocator, &(values[id]));
         }
         allocator.deallocate(values, capacity);
         capacity = 0;

--- a/lemon/path.h
+++ b/lemon/path.h
@@ -663,7 +663,7 @@ namespace lemon {
     void clear() {
       while (first != 0) {
         last = first->next;
-        alloc.destroy(first);
+        std::allocator_traits<std::allocator<Node>>::destroy(alloc, first);
         alloc.deallocate(first, 1);
         first = last;
       }
@@ -698,7 +698,7 @@ namespace lemon {
       } else {
         last = 0;
       }
-      alloc.destroy(node);
+      std::allocator_traits<std::allocator<Node>>::destroy(alloc, node);
       alloc.deallocate(node, 1);
     }
 
@@ -731,7 +731,7 @@ namespace lemon {
       } else {
         first = 0;
       }
-      alloc.destroy(node);
+      std::allocator_traits<std::allocator<Node>>::destroy(alloc, node);
       alloc.deallocate(node, 1);
     }
 


### PR DESCRIPTION
…destroy

C++20 fix, backwards compatible to C++11

https://en.cppreference.com/w/cpp/memory/allocator/destroy was remove in c++20. Replace with https://en.cppreference.com/w/cpp/memory/allocator_traits/destroy